### PR TITLE
Fixes for compatibility with later nodejs

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -11,7 +11,7 @@ module.exports = function(/*String*/inPath) {
         _filename = "";
 
     if (inPath && typeof inPath === "string") { // load zip file
-        if (pth.existsSync(inPath)) {
+        if (fs.existsSync(inPath)) {
             _filename = inPath;
             _zip = new ZipFile(fs.readFileSync(inPath));
         } else {
@@ -67,7 +67,7 @@ module.exports = function(/*String*/inPath) {
             if (item) {
                 item.getDataAsync(callback);
             } else {
-                callback(null)
+                callback(null,"getEntry failed for:"+entry)
             }
         },
         /**
@@ -187,7 +187,7 @@ module.exports = function(/*String*/inPath) {
          * @param localPath
          */
         addLocalFile : function(/*String*/localPath) {
-             if (pth.existsSync(localPath)) {
+            if (fs.existsSync(localPath)) {
                   // do stuff
              } else {
                  throw Utils.Errors.FILE_NOT_FOUND.replace("%s", localPath);
@@ -200,18 +200,19 @@ module.exports = function(/*String*/inPath) {
          * @param localPath
          */
         addLocalFolder : function(/*String*/localPath) {
-            if (localPath.charAt(localPath.length - 1) != "/")
+            localPath = localPath.split("\\").join("/");//windows fix
+			if (localPath.charAt(localPath.length - 1) != "/")
                 localPath += "/";
-
-            if (pth.existsSync(localPath)) {
-                var items = Utils.findFiles(localPath);
+			
+			if (fs.existsSync(localPath)) {
+				var items = Utils.findFiles(localPath);
                 if (items.length) {
                     items.forEach(function(path) {
                         var entry = new ZipEntry();
-                        entry.entryName = path.replace(localPath, "");
-                        var stats = fs.statSync(path);
+                        entry.entryName = path.split("\\").join("/").replace(localPath, "");//windows fix
+						var stats = fs.statSync(path);
                         if (stats.isDirectory()) {
-                            entry.setData("");
+						    entry.setData("");
                             entry.header.inAttr = stats.mode;
                             entry.header.attr = stats.mode
                         } else {
@@ -316,7 +317,7 @@ module.exports = function(/*String*/inPath) {
             var content = item.getData();
             if (!content) throw Utils.Errors.CANT_EXTRACT_FILE;
 
-            if (pth.existsSync(targetPath) && !overwrite) {
+            if (fs.existsSync(targetPath) && !overwrite) {
                 throw Utils.Errors.CANT_OVERRIDE;
             }
             Utils.writeFileTo(target, content, overwrite);

--- a/util/fattr.js
+++ b/util/fattr.js
@@ -19,7 +19,7 @@ module.exports = function(/*String*/path) {
         }
     }
 
-    if (_path && pth.existsSync(_path)) {
+    if (_path && fs.existsSync(_path)) {
         _stat = fs.statSync(_path);
         _obj.directory = _stat.isDirectory();
         _obj.mtime = _stat.mtime;

--- a/util/utils.js
+++ b/util/utils.js
@@ -85,7 +85,7 @@ module.exports = (function() {
         },
 
         writeFileTo : function(/*String*/path, /*Buffer*/content, /*Boolean*/overwrite, /*Number*/attr) {
-            if (pth.existsSync(path)) {
+            if (fs.existsSync(path)) {
                 if (!overwrite)
                     return false; // cannot overwite
 
@@ -95,7 +95,7 @@ module.exports = (function() {
                 }
             }
             var folder = pth.dirname(path);
-            if (!pth.existsSync(folder)) {
+            if (!fs.existsSync(folder)) {
                 mkdirSync(folder);
             }
 


### PR DESCRIPTION
I used adm-zip in a project and needed to make the following changes to fix compatibility problems with the later node versions (basically using fs instead of path). I also made some minor changes to return the error reason and one fix if the CRC was wrong.
