### PR TITLE
Simple one line fix for "path.existsSync is now called fs.existsSync"

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -87,7 +87,7 @@ module.exports = (function() {
         },
 
         writeFileTo : function(/*String*/path, /*Buffer*/content, /*Boolean*/overwrite, /*Number*/attr) {
-            if (pth.existsSync(path)) {
+            if (fs.existsSync(path)) {
                 if (!overwrite)
                     return false; // cannot overwite
 


### PR DESCRIPTION
Applied the same

```
fs.existsSync = fs.existsSync || pth.existsSync;
```

to utils.js that you had missed. Just a simple one line change.
