### PR TITLE
fix for path.existsSync warning

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -87,7 +87,7 @@ module.exports = (function() {
         },
 
         writeFileTo : function(/*String*/path, /*Buffer*/content, /*Boolean*/overwrite, /*Number*/attr) {
-            if (pth.existsSync(path)) {
+            if (fs.existsSync(path)) {
                 if (!overwrite)
                     return false; // cannot overwite
 


### PR DESCRIPTION
Implemented the fix in the same way as the rest of the project:

fs.existsSync = fs.existsSync || pth.existsSync;

and then swapped pth.existsSync for fs.existsSync. 

Simple one line fix so that I don't get any warnings while running the code.
