### PR TITLE
Updated sample code for zip.extractEntryTo. Added maintainEntryPath param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are no other nodeJS libraries that ADM-ZIP is dependent of
 	// outputs the content of some_folder/my_file.txt
 	console.log(zip.readAsText("some_folder/my_file.txt")); 
 	// extracts the specified file to the specified location
-	zip.extractEntryTo(/*entry name*/"some_folder/my_file.txt", /*target path*/"/home/me/tempfolder", /*overwrite*/true)
+	zip.extractEntryTo(/*entry name*/"some_folder/my_file.txt", /*target path*/"/home/me/tempfolder", /*maintainEntryPath*/false, /*overwrite*/true);
 	// extracts everything
 	zip.extractAllTo(/*target path*/"/home/me/zipcontent/", /*overwrite*/true);
 	


### PR DESCRIPTION
Hey cthackers,

I updated the basic usage sample code for zip.extractEntryTo and added maintainEntryPath parameter on the README.md file. This is the change that I meant on my comment [here](https://github.com/cthackers/adm-zip/issues/54#issuecomment-21537703). I agree that your documentation is correct over [this section](https://github.com/cthackers/adm-zip/wiki/ADM-ZIP#wiki-a18). I'm only referring to the sample code on the README.md file.

Regards,

Third
