### PR TITLE
Preserve entry.attr in header

### DIFF
--- a/zipEntry.js
+++ b/zipEntry.js
@@ -240,6 +240,9 @@ module.exports = function (/*Buffer*/input) {
             decompress(true, callback)
         },
 
+        set attr(attr) { _entryHeader.attr = attr; },
+        get attr() { return _entryHeader.attr; },
+
         set header(/*Buffer*/data) {
             _entryHeader.loadFromBinary(data);
         },


### PR DESCRIPTION
The attr field is paid no attention whatsoever, when adding a file to a zip archive, even though it is assumed to be in [addFile](https://github.com/cthackers/adm-zip/blob/master/adm-zip.js#L259).

This patch fixes that, allowing the user to preserve the attr field in the header.
