### PR TITLE
addLocalFolder doesn't work properly under windows

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -235,8 +235,9 @@ module.exports = function(/*String*/input) {
             }else{
                 zipPath="";
             }
-			localPath = localPath.split("\\").join("/"); //windows fix
+            // normalize the path first
             localPath = pth.normalize(localPath);
+	    localPath = localPath.split("\\").join("/"); //windows fix
             if (localPath.charAt(localPath.length - 1) != "/")
                 localPath += "/";
 


### PR DESCRIPTION
Under windows, the path should be normalize first, otherwise the localPath will still use back slash
