### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
         "email": "sy@another-d-mention.ro",
         "url": "https://github.com/cthackers/adm-zip/issues"
     },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://raw.github.com/cthackers/adm-zip/master/MIT-LICENSE.txt"
-        }
-    ],
+    "license": "MIT",
     "files": [
         "adm-zip.js",
         "headers",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
