### PR TITLE
Added support for electron original-fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ADM-ZIP for NodeJS
+# ADM-ZIP for NodeJS with added support for electron original-fs
+
+* see comit https://github.com/kadledav/adm-zip/commit/3902bb2639dc4a39f1a2e8566219e085ff12a9d0
 
 ADM-ZIP is a pure JavaScript implementation for zip data compression for [NodeJS](http://nodejs.org/). 
 

--- a/adm-zip.js
+++ b/adm-zip.js
@@ -1,11 +1,11 @@
-var fs = require("fs"),
+var Utils = require("./util");
+var fs = Utils.FileSystem.require(),
     pth = require("path");
 
 fs.existsSync = fs.existsSync || pth.existsSync;
 
 var ZipEntry = require("./zipEntry"),
-    ZipFile =  require("./zipFile"),
-    Utils = require("./util");
+    ZipFile =  require("./zipFile");
 
 module.exports = function(/*String*/input) {
     var _zip = undefined,

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "adm-zip",
+    "name": "adm-zip-electron",
     "version": "0.4.7",
-    "description": "A Javascript implementation of zip for nodejs. Allows user to create or extract zip files both in memory or to/from disk",
+    "description": "Fork of a Javascript implementation of zip for nodejs with support for electron original-fs. Allows user to create or extract zip files both in memory or to/from disk",
     "keywords": [
         "zip",
         "methods",
         "archive",
         "unzip"
     ],
-    "homepage": "http://github.com/cthackers/adm-zip",
+    "homepage": "https://github.com/kadledav/adm-zip",
     "author": "Nasca Iacob <sy@another-d-mention.ro> (https://github.com/cthackers)",
     "bugs": {
         "email": "sy@another-d-mention.ro",

--- a/util/fattr.js
+++ b/util/fattr.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
+var fs = require("./fileSystem").require(),
     pth = require("path");
 	
 fs.existsSync = fs.existsSync || pth.existsSync;

--- a/util/fileSystem.js
+++ b/util/fileSystem.js
@@ -1,0 +1,3 @@
+exports.require = function() {
+  return require(process.versions['electron'] ? "original-fs" : "fs");
+};

--- a/util/index.js
+++ b/util/index.js
@@ -1,4 +1,5 @@
 module.exports = require("./utils");
+module.exports.FileSystem = require("./fileSystem");
 module.exports.Constants = require("./constants");
 module.exports.Errors = require("./errors");
 module.exports.FileAttr = require("./fattr");

--- a/util/utils.js
+++ b/util/utils.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
+var fs = require("./fileSystem").require(),
     pth = require('path');
 
 fs.existsSync = fs.existsSync || pth.existsSync;

--- a/zipFile.js
+++ b/zipFile.js
@@ -7,7 +7,7 @@ module.exports = function(/*String|Buffer*/input, /*Number*/inputType) {
         entryTable = {},
         _comment = new Buffer(0),
         filename = "",
-        fs = require("fs"),
+        fs = Utils.FileSystem.require(),
         inBuffer = null,
         mainHeader = new Headers.MainHeader();
 


### PR DESCRIPTION
We are using your library in the Electron browser. If we need to unpack an archive with *.asar file in that archive we receive an exception. The problem is because Electron modifies the "fs" module. If we use the unmodified fs module which can be referenced as "original-fs" your library works fine. 
