### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -213,7 +213,7 @@ module.exports = function () {
             // modification time (2 bytes time, 2 bytes date)
             data.writeUInt32LE(_time, Constants.CENTIM);
             // uncompressed file crc-32 value
-            data.writeInt32LE(_crc, Constants.CENCRC, true);
+            data.writeInt32LE(_crc, Constants.CENCRC);
             // compressed size
             data.writeUInt32LE(_compressedSize, Constants.CENSIZ);
             // uncompressed size


### PR DESCRIPTION
The support for the `noAssert` argument dropped for the upcoming
Node.js 10.x release. This just removes the argument and should not
have any further impact.

https://github.com/nodejs/node/pull/18395