### PR TITLE
fix: prevent extracting archived files outside of target path

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -354,6 +354,9 @@ module.exports = function(/*String*/input) {
 
 
             var target = pth.resolve(targetPath, maintainEntryPath ? entryName : pth.basename(entryName));
+            if(!target.startsWith(targetPath)) {
+                throw Utils.Errors.INVALID_FILENAME + ": " + entryName;
+            }
 
             if (item.isDirectory) {
                 target = pth.resolve(target, "..");
@@ -429,6 +432,10 @@ module.exports = function(/*String*/input) {
             _zip.entries.forEach(function(entry) {
                 entryName = entry.entryName.toString();
 
+                if(!pth.resolve(targetPath, entryName).startsWith(targetPath)) {
+                    throw Utils.Errors.INVALID_FILENAME + ": " + entryName;
+                }
+
                 if(isWin){
                     entryName = escapeFileName(entryName)
                 }
@@ -469,6 +476,10 @@ module.exports = function(/*String*/input) {
 
                 if(isWin){
                     entryName = escapeFileName(entryName)
+                }
+
+                if(!pth.resolve(targetPath, entryName).startsWith(targetPath)) {
+                  throw Utils.Errors.INVALID_FILENAME + ": " + entryName;
                 }
 
                 if (entry.isDirectory) {


### PR DESCRIPTION
## Why this PR?
This PR is meant to fix an arbitrary file write vulnerability, that can be achieved using a specially crafted zip archive, that holds path traversal filenames. When the filename gets concatenated to the target extraction directory, the final path ends up outside of the target folder. 

A sample malicious zip file named zip-slip.zip. (see [this gist](https://gist.github.com/grnd/2992cc4d968386ae277123bad9e7f00a)) was used, and when running the code below, resulted in creation of `evil.txt` file in /tmp folder.

```js
var AdmZip = require('adm-zip');
var zip = new AdmZip("./zip-slip.zip");
zip.extractAllTo("/tmp/safe");
```

There are various possible ways to avoid this issue, some include checking for `..` (dot dot) characters in the filename, but the best solution in our opinion is to check if the final target filename, starts with the target folder (after both are resolved to their absolute path).

Stay secure,
Snyk Team