### PR TITLE
Updated entryHeaderToBinary. 

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -213,7 +213,7 @@ module.exports = function () {
             // modification time (2 bytes time, 2 bytes date)
             data.writeUInt32LE(_time, Constants.CENTIM);
             // uncompressed file crc-32 value
-            data.writeInt32LE(_crc, Constants.CENCRC);
+            data.writeUInt32LE(_crc, Constants.CENCRC);
             // compressed size
             data.writeUInt32LE(_compressedSize, Constants.CENSIZ);
             // uncompressed size


### PR DESCRIPTION
Fixed a typo that made the CRC be written as an Int32 instead of a UInt32.

This caused some ZIP file creations to return an error, and not work correctly. Please advise if fix is incorrect.

Thanks! :)