### PR TITLE
Fix octal literals so they work in strict mode

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -288,9 +288,9 @@ module.exports = function(/*String*/input) {
 
             if (!attr) {
                 if (entry.isDirectory) {
-                    attr = (040755 << 16) | 0x10; // (permissions drwxr-xr-x) + (MS-DOS directory flag)
+                    attr = (0o40755 << 16) | 0x10; // (permissions drwxr-xr-x) + (MS-DOS directory flag)
                 } else {
-                    attr = 0644 << 16; // permissions -r-wr--r--
+                    attr = 0o644 << 16; // permissions -r-wr--r--
                 }
             }
 


### PR DESCRIPTION
I had a few issues using adm-zip with es6 imports (strict mode). I fixed it by changing the depricated octals.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal

![octal](https://user-images.githubusercontent.com/1066160/39791418-9619a8a2-5309-11e8-9c8f-85414fe33484.png)

