### PR TITLE
[REFACTOR]: include the given filename when throwing INVALID_FILENAME

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -19,7 +19,7 @@ module.exports = function (/*String*/input) {
 			_filename = input;
 			_zip = new ZipFile(input, Utils.Constants.FILE);
 		} else {
-			throw Utils.Errors.INVALID_FILENAME;
+			throw Utils.Errors.INVALID_FILENAME + ': ' + input;
 		}
 	} else if (input && Buffer.isBuffer(input)) { // load buffer
 		_zip = new ZipFile(input, Utils.Constants.BUFFER);


### PR DESCRIPTION
This change just appends the given filename to the error message in cases where an invalid filename is  given. This is helpful for debugging. Right now the message is simply "Invalid filename".

I didn't see a contribution guide, but let me know if I missed it and need to make any changes here 👍 