### PR TITLE
fix bug when filename or path contains multi-byte characters

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -199,7 +199,7 @@ module.exports = (function() {
                 if (input.length === 0) {
                     return Buffer.alloc(0)
                 }
-                return Buffer.alloc(input.length, input, 'utf8');
+                return Buffer.from(input, 'utf8');
             }
         },
 

--- a/zipFile.js
+++ b/zipFile.js
@@ -191,8 +191,12 @@ module.exports = function (/*String|Buffer*/input, /*Number*/inputType) {
 				// data header
 				entry.header.offset = dindex;
 				var dataHeader = entry.header.dataHeaderToBinary();
-				var c = entry.entryName + entry.extra.toString();
-				var postHeader = Buffer.alloc(c.length, c);
+				var entryNameLen = entry.rawEntryName.length;
+				var extra = entry.extra.toString();
+				var postHeader = Buffer.alloc(entryNameLen + extra.length);
+				entry.rawEntryName.copy(postHeader, 0);
+				postHeader.fill(extra, entryNameLen);
+
 				var dataLength = dataHeader.length + postHeader.length + compressedData.length;
 
 				dindex += dataLength;


### PR DESCRIPTION
In multi-byte utf-8 string, the "string.length" is not equal to buffer bytes length.
Zipping a file or directory with multi-byte character in the name will corrupt the zip file.