### PR TITLE
Add a full license text to the distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "methods",
     "util",
     "zipEntry.js",
-    "zipFile.js"
+    "zipFile.js",
+    "MIT-LICENSE.txt"
   ],
   "main": "adm-zip.js",
   "repository": {


### PR DESCRIPTION
Without this, the package distributed on npm is unlicensed, proprietary, and nobody can use it. (No, the SPDX identifier in the package.json is not enough legally.)

This change should be released as a new patch version so it virally distributes to all projects depending on this library.