### PR TITLE
Fix: bad buffer.alloc for .toBuffer in async mode

### DIFF
--- a/zipFile.js
+++ b/zipFile.js
@@ -267,7 +267,7 @@ module.exports = function (/*String|Buffer*/input, /*Number*/inputType) {
 						entry.header.offset = dindex;
 						// data header
 						var dataHeader = entry.header.dataHeaderToBinary();
-						var postHeader = Buffer.alloc(name);
+						var postHeader = Buffer.from(name);
 						var dataLength = dataHeader.length + postHeader.length + compressedData.length;
 
 						dindex += dataLength;


### PR DESCRIPTION
Fixes the "toBuffer" function in async mode (with callback supplied)