### PR TITLE
fix race-condition crash when extracting data and extracted files are (re)moved

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -440,7 +440,11 @@ module.exports = function (/*String*/input) {
 					throw Utils.Errors.CANT_EXTRACT_FILE;
 				}
 				Utils.writeFileTo(entryName, content, overwrite);
-				fs.utimesSync(entryName, entry.header.time, entry.header.time)
+				try {
+					fs.utimesSync(entryName, entry.header.time, entry.header.time)
+				} catch (err) {
+					throw Utils.Errors.CANT_EXTRACT_FILE;
+				}
 			})
 		},
 
@@ -488,7 +492,11 @@ module.exports = function (/*String*/input) {
 					}
 
 					Utils.writeFileToAsync(sanitize(targetPath, entryName), content, overwrite, function (succ) {
-						fs.utimesSync(pth.resolve(targetPath, entryName), entry.header.time, entry.header.time);
+						try {
+							fs.utimesSync(pth.resolve(targetPath, entryName), entry.header.time, entry.header.time);
+						} catch (err) {
+							callback(new Error('Unable to set utimes'));
+						}
 						if (i <= 0) return;
 						if (!succ) {
 							i = 0;

--- a/util/fileSystem.js
+++ b/util/fileSystem.js
@@ -2,7 +2,10 @@ exports.require = function() {
   var fs = require("fs");
   if (process.versions['electron']) {
 	  try {
-		  fs = require("original-fs")
+	    originalFs = require("original-fs");
+	    if (Object.keys(originalFs).length > 0) {
+	      fs = originalFs;
+      }
 	  } catch (e) {}
   }
   return fs


### PR DESCRIPTION
To reproduce you can extract a zip file with known contents while deleting the extracted files in a loop, e.g.

A zip file, `foo.zip` with the content:

     bar.txt

Then, in a shell run a loop that triggers this race condition:

     $ while true; do rm bar.txt; done

In another shell, extract your files:

      AdmZip('foo.zip').extractAllToAsync(...)

This will then crash and take your node process with it, because the file will have been removed between the `Utils.writeFileToAsync` and `fs.utimesSync` calls.

This PR fixes this bug and will return an error when this condition occurs.