### PR TITLE
fix: CRC is unexpectedly changed after zip is re-created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules/
-test/issue_*/unzipped/
+node_modules
+/test/issue_*/unzipped/
+xxx
 .idea
 *.iml

--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -213,7 +213,7 @@ module.exports = function () {
             // modification time (2 bytes time, 2 bytes date)
             data.writeUInt32LE(_time, Constants.CENTIM);
             // uncompressed file crc-32 value
-            data.writeInt32LE(_crc & 0xFFFF, Constants.CENCRC, true);
+            data.writeUInt32LE(_crc, Constants.CENCRC);
             // compressed size
             data.writeUInt32LE(_compressedSize, Constants.CENSIZ);
             // uncompressed size

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.12",
   "description": "Javascript implementation of zip for nodejs with support for electron original-fs. Allows user to create or extract zip files both in memory or to/from disk",
   "scripts": {
-    "test": "mocha test/mocha.js"
+    "test": "mocha test/mocha.js test/crc/index.js"
   },
   "keywords": [
     "zip",


### PR DESCRIPTION
This was fixed in #228, but broken by #240 again!
`data.writeInt32LE(_crc & 0xFFFF, Constants.CENCRC)` breaks crc over 0xFFFF.

Also adding test code to `test/crc/index.js` and run it in CI.