### PR TITLE
Fixed async decompression of empty zip entries.

### DIFF
--- a/zipEntry.js
+++ b/zipEntry.js
@@ -47,9 +47,10 @@ module.exports = function (/*Buffer*/input) {
         }
 
         var compressedData = getCompressedDataFromZip();
-       
+
         if (compressedData.length === 0) {
-            if (async && callback) callback(compressedData, Utils.Errors.NO_DATA);//si added error.
+            // File is empty, nothing to decompress.
+            if (async && callback) callback(compressedData);
             return compressedData;
         }
 


### PR DESCRIPTION
Code was improperly raising an error when trying to decompress entries with 0 length buffer (ie. empty file), even though it seemingly wasn't concerned about it if decompression was synchronised.
I removed the async error since having empty files in an archive is a perfectly valid thing.