### PR TITLE
Escape $ sign for regex in addLocalFolder()

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -272,7 +272,7 @@ module.exports = function (/*String*/input) {
 
 				if (items.length) {
 					items.forEach(function (path) {
-						var p = path.split("\\").join("/").replace(new RegExp(localPath.replace(/(\(|\))/g, '\\$1'), 'i'), ""); //windows fix
+						var p = path.split("\\").join("/").replace(new RegExp(localPath.replace(/(\(|\)|\$)/g, '\\$1'), 'i'), ""); //windows fix
 						if (filter(p)) {
 							if (p.charAt(p.length - 1) !== "/") {
 								self.addFile(zipPath + p, fs.readFileSync(path), "", 0)


### PR DESCRIPTION
Fixes #278 where using `addLocalFile()` with a $ sign somewhere in the path would not correctly get the relative filepath from localPath.

This is a quick and "dirty" fix, but a better way would be to replace the current regex generation code with `path.relative(from, to)` or look at what some other packages do, like `escape-string-regexp`  which has a better regex for escaping strings: `/[|\\{}()[\]^$+*?.]/`. Even if some of these characters are not valid in paths, we could be sure that nothing wrong happens with the regex.