### PR TITLE
Update Node.js version to use in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - 8
-  - 6
+  - 'stable'
+  - 12
+  - 10
 
 cache:
   directories:


### PR DESCRIPTION
Update Node.js versions used in Travis CI test with all active LTS versions(10.x, 12.x) + the latest stable version (14.x at the moment).

Reference: https://nodejs.org/en/about/releases/