### PR TITLE
Update zipFile.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adm-zip",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Javascript implementation of zip for nodejs with support for electron original-fs. Allows user to create or extract zip files both in memory or to/from disk",
   "scripts": {
     "test": "mocha test/mocha.js test/crc/index.js"

--- a/zipFile.js
+++ b/zipFile.js
@@ -304,7 +304,7 @@ module.exports = function (/*String|Buffer*/input, /*Number*/inputType) {
 
 			var mh = mainHeader.toBinary();
 			if (_comment) {
-				_comment.copy(mh, Utils.Constants.ENDHDR); // add zip file comment
+				Buffer.from(_comment).copy(mh, Utils.Constants.ENDHDR); // add zip file comment
 			}
 
 			mh.copy(outBuffer, dindex); // write main header


### PR DESCRIPTION
Typecast _comment to Buffer to avoid copying errors.

Linked to issue: https://github.com/cthackers/adm-zip/issues/197
