### PR TITLE
Lower verMade for macOS when generating zip file

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -23,8 +23,6 @@ module.exports = function () {
     switch(process.platform){
         case 'win32':
             _verMade |= 0x0A00;
-        case 'darwin':
-            _verMade |= 0x1300;
         default:
             _verMade |= 0x0300;
     }


### PR DESCRIPTION
fix #345

The highest version of zip is currently 6.x (ref: https://en.wikipedia.org/wiki/ZIP_(file_format) ), but we are setting 'version made by' to 0x1314 when generating zip on macOS

If the "version made by" is set to 0x1314, while extracting the zip with `unzip` command, the execute permissions of files will be lost. So I change it to 0x0314.