### PR TITLE
added second parameter "options"

### DIFF
--- a/util/constants.js
+++ b/util/constants.js
@@ -98,9 +98,9 @@ module.exports = {
     FLG_MSK          : 4096, // mask header values
 
     /* Load type */
-    FILE             : 0,
+    FILE             : 2,
     BUFFER           : 1,
-    NONE             : 2,
+    NONE             : 0,
 
     /* 4.5 Extensible data fields */
     EF_ID            : 0,

--- a/zipEntry.js
+++ b/zipEntry.js
@@ -4,7 +4,6 @@ var Utils = require("./util"),
     Methods = require("./methods");
 
 module.exports = function (/*Buffer*/input) {
-
     var _entryHeader = new Headers.EntryHeader(),
         _entryName = Buffer.alloc(0),
         _comment = Buffer.alloc(0),
@@ -90,7 +89,7 @@ module.exports = function (/*Buffer*/input) {
                         } else { //si added otherwise did not seem to return data.
                             if (callback) callback(data);
                         }
-                    })
+                    });
                 }
                 break;
             default:
@@ -132,7 +131,7 @@ module.exports = function (/*Buffer*/input) {
                             _entryHeader.compressedSize = data.length;
                             data.copy(compressedData);
                             callback && callback(compressedData);
-                        })
+                        });
                     }
                     deflater = null;
                     break;


### PR DESCRIPTION
add second parameter "options"
- with this you may add more options to customise specific aspects how program works
- options chaining gives zipfile and adm-zip ability exchange data without explicitly write/read it from one to other.
- moved file reading part from zipfile.js to adm-zip.js so file IO operations happen only in adm-zip.js file and zipfile.js handles just buffer from file.
- changed constant values so 0 will be none.
- without second parameter adm-zip acts exactly same as before.