### PR TITLE
Canonical function

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -10,8 +10,9 @@ var ZipEntry = require("./zipEntry"),
 var isWin = /^win/.test(process.platform);
 
 function canonical(p) {
-    var safeSuffix = pth.normalize(p).replace(/^(\.\.(\/|\\|$))+/, '');
-    return pth.join('./', safeSuffix);
+    // trick normalize think path is absolute
+    var safeSuffix = pth.posix.normalize('/' + p.split("\\").join("/"));
+    return pth.join('.', safeSuffix);
 }
 
 module.exports = function (/**String*/input) {
@@ -61,12 +62,9 @@ module.exports = function (/**String*/input) {
 	}
 
     function fixPath(zipPath){
+        const { join, normalize } = pth.posix;
         // convert windows file separators and normalize
-        zipPath = pth.posix.normalize(zipPath.split("\\").join("/"));
-        // cleanup, remove invalid folder names
-        var names = zipPath.split("/").filter((c) => c !== "" && c !== "." && c !== "..");
-        // if we have name we return it
-        return names.length ? names.join("/") + "/" : "";
+        return join('.', normalize('/' + zipPath.split("\\").join("/") + '/'));
     }
 
 	return {

--- a/adm-zip.js
+++ b/adm-zip.js
@@ -11,8 +11,8 @@ var isWin = /^win/.test(process.platform);
 
 function canonical(p) {
     // trick normalize think path is absolute
-    var safeSuffix = pth.posix.normalize('/' + p.split("\\").join("/"));
-    return pth.join('.', safeSuffix);
+    var safeSuffix = pth.posix.normalize("/" + p.split("\\").join("/"));
+    return pth.join(".", safeSuffix);
 }
 
 module.exports = function (/**String*/input) {
@@ -62,9 +62,9 @@ module.exports = function (/**String*/input) {
 	}
 
     function fixPath(zipPath){
-        const { join, normalize } = pth.posix;
+        const { join, normalize, sep } = pth.posix;
         // convert windows file separators and normalize
-        return join('.', normalize('/' + zipPath.split("\\").join("/") + '/'));
+        return join(".", normalize(sep + zipPath.split("\\").join(sep) + sep));
     }
 
 	return {


### PR DESCRIPTION
I looked #343 and proposed canonical function has its flaws.
- It will catch "../bin/runme.js", but 
- it will not catch "dummy/../../bin/runme.js" 
- if you normalize them you get same result: "../bin/runme.js".

I propose still use [path.normalize](https://nodejs.org/docs/latest-v14.x/api/path.html#path_path_normalize_path) but trick it to think it has absolute paths and in that mode it prevents paths go deeper than root folder. After that [path.join](path.join([...paths])) will translate it back to relative path, like before.