### PR TITLE
Use Buffer.from instead of allocating with length

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -62,7 +62,7 @@ module.exports = (function() {
 
         crc32 : function(buf) {
             if (typeof buf === 'string') {
-                buf = Buffer.alloc(buf.length, buf);
+                buf = Buffer.from(buf);
             }
             var b = Buffer.alloc(4);
             if (!crcTable.length) {


### PR DESCRIPTION
The CRC32 created for documents using UTF-8 characters is wrong because the buffer was created using the wrong number of bytes.

```
> Buffer.alloc("Testǭ".length,"Testǭ").toString()
'Test�'
> Buffer.from("Testǭ").toString()
'Testǭ'
```

The Testǭ string is indeed of length 5 while its byte length is 6...

This means that if we call `zipEntry.setData()` with a string, the resulting entry will have incorrect CRC32, while calling it with a buffer works since the code does not do the string->buffer translation itself.