### PR TITLE
redo process object tests

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -450,7 +450,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
             var fileattr = entry.isDirectory ? 0x10 : 0; // (MS-DOS directory flag)
 
             // extended attributes field for Unix
-            if ("win32" !== process.platform) {
+            if (!Utils.isWin) {
                 // set file type either S_IFDIR / S_IFREG
                 let unix = entry.isDirectory ? 0x4000 : 0x8000;
 

--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -19,12 +19,7 @@ module.exports = function () {
         _attr = 0,
         _offset = 0;
 
-    switch (process.platform) {
-        case "win32":
-            _verMade |= 0x0a00;
-        default:
-            _verMade |= 0x0300;
-    }
+    _verMade |= Utils.isWin ? 0x0a00 : 0x0300;
 
     var _dataHeader = {};
 

--- a/util/fileSystem.js
+++ b/util/fileSystem.js
@@ -1,12 +1,11 @@
 exports.require = function () {
-    var fs = require("fs");
-    if (process && process.versions && process.versions["electron"]) {
+    if (typeof process === "object" && process.versions && process.versions["electron"]) {
         try {
-            originalFs = require("original-fs");
+            const originalFs = require("original-fs");
             if (Object.keys(originalFs).length > 0) {
-                fs = originalFs;
+                return originalFs;
             }
         } catch (e) {}
     }
-    return fs;
+    return require("fs");
 };

--- a/util/utils.js
+++ b/util/utils.js
@@ -1,7 +1,9 @@
-var fs = require("./fileSystem").require(),
-    pth = require("path");
+const fs = require("./fileSystem").require();
+const pth = require("path");
 
 fs.existsSync = fs.existsSync || pth.existsSync;
+
+const isWin = typeof process === "object" && "win32" === process.platform;
 
 module.exports = (function () {
     var crcTable = [],
@@ -193,6 +195,8 @@ module.exports = (function () {
                 return Buffer.from(input, "utf8");
             }
         },
+
+        isWin, // Do we have windows system
 
         readBigUInt64LE,
 


### PR DESCRIPTION
if using `process` directly without testing, it will throw in some environments like browsers (probably even in some cases in electrons browser window). So we should test is it object, so it will fail early.

* added **inWin** prop since it wont change we test it once and store value.
* updated filesystem so it will call require with **fs** only if **original-fs** is not found