### PR TITLE
added "noSort" option

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -7,6 +7,8 @@ const fs = Utils.FileSystem.require();
 fs.existsSync = fs.existsSync || pth.existsSync;
 
 const defaultOptions = {
+    // option "noSort" : if true it disables files sorting
+    noSort: false,
     // read entries during load (initial loading may be slower)
     readEntries: false,
     // default method is none

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -95,6 +95,36 @@ describe("adm-zip", () => {
         expect(text).to.equal("ride em cowboy!");
         fs.unlinkSync("./text.txt");
     });
+
+    it("testing noSort option", () => {
+        const content = "test";
+        const comment = "comment";
+        let temp = null;
+
+        // is sorting working - value "false"
+        const zip1 = new Zip({ noSort: false });
+        zip1.addFile("a.txt", content, comment);
+        zip1.addFile("c.txt", content, comment);
+        zip1.addFile("b.txt", content, comment);
+        zip1.addFile("a.txt", content, comment);
+        temp = zip1.toBuffer();
+
+        const zip1Entries = zip1.getEntries().map((e) => e.entryName);
+        expect(zip1Entries).to.deep.equal(["a.txt", "b.txt", "c.txt"]);
+
+        // skip sorting - value "true"
+        const zip2 = new Zip({ noSort: true });
+        zip1.addFile("a.txt", content, comment);
+        zip2.addFile("c.txt", content, comment);
+        zip2.addFile("b.txt", content, comment);
+        zip2.addFile("a.txt", content, comment);
+        temp = zip2.toBuffer();
+
+        const zip2Entries = zip2.getEntries().map((e) => e.entryName);
+        expect(zip2Entries).to.deep.equal(["c.txt", "b.txt", "a.txt"]);
+
+        var g = 9;
+    });
 });
 
 function walk(dir) {

--- a/zipFile.js
+++ b/zipFile.js
@@ -12,6 +12,8 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
     // assign options
     const opts = Object.assign(Object.create(null), options);
 
+    const { noSort } = opts;
+
     if (inBuffer) {
         // is a memory buffer
         readMainHeader(opts.readEntries);
@@ -103,6 +105,12 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             _comment = inBuffer.slice(commentEnd + Utils.Constants.ENDHDR);
         }
         if (readNow) readEntries();
+    }
+
+    function sortEntries() {
+        if (entryList.length > 1 && !noSort) {
+            entryList.sort((a, b) => a.entryName.toLowerCase().localeCompare(b.entryName.toLowerCase()));
+        }
     }
 
     return {
@@ -231,19 +239,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             if (!loadedEntries) {
                 readEntries();
             }
-            if (entryList.length > 1) {
-                entryList.sort(function (a, b) {
-                    var nameA = a.entryName.toLowerCase();
-                    var nameB = b.entryName.toLowerCase();
-                    if (nameA < nameB) {
-                        return -1;
-                    }
-                    if (nameA > nameB) {
-                        return 1;
-                    }
-                    return 0;
-                });
-            }
+            sortEntries();
 
             var totalSize = 0,
                 dataBlock = [],
@@ -308,19 +304,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             if (!loadedEntries) {
                 readEntries();
             }
-            if (entryList.length > 1) {
-                entryList.sort(function (a, b) {
-                    var nameA = a.entryName.toLowerCase();
-                    var nameB = b.entryName.toLowerCase();
-                    if (nameA > nameB) {
-                        return -1;
-                    }
-                    if (nameA < nameB) {
-                        return 1;
-                    }
-                    return 0;
-                });
-            }
+            sortEntries();
 
             var totalSize = 0,
                 dataBlock = [],


### PR DESCRIPTION
option not sort is useful when processing some files like ".jar" files for example.

- added "noSort" option, with this all files keep their order.
- added simple test for it

should solve #200