### PR TITLE
allow to ignore the original permission when extracting

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -149,7 +149,7 @@ module.exports = function () {
 
         // get Unix file permissions
         get fileAttr() {
-            return (((_attr >>> 0) | 0) >> 16) & 0xfff;
+            return _attr ? (((_attr >>> 0) | 0) >> 16) & 0xfff : 0;
         },
 
         get offset() {


### PR DESCRIPTION
- offer an option for ignoring original permission in the zip file, when extracting it.
- add the default value for fileAttr in enteryHeader