### PR TITLE
Fix parameter initialization bug of extractAllToAsync

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -633,12 +633,14 @@ module.exports = function (/**String*/ input, /** object */ options) {
          * @param callback The callback will be executed when all entries are extracted successfully or any error is thrown.
          */
         extractAllToAsync: function (/**String*/ targetPath, /**Boolean*/ overwrite, /**Boolean*/ keepOriginalPermission, /**Function*/ callback) {
-            if (!callback) {
-                callback = function () {};
-            }
             overwrite = get_Bool(overwrite, false);
             if (typeof keepOriginalPermission === "function" && !callback) callback = keepOriginalPermission;
             keepOriginalPermission = get_Bool(keepOriginalPermission, false);
+            if (!callback) {
+                callback = function (err) {
+                    throw new Error(err);
+                };
+            }
             if (!_zip) {
                 callback(new Error(Utils.Errors.NO_ZIP));
                 return;

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -44,6 +44,20 @@ describe("adm-zip", () => {
             );
             done();
         });
+        zip.extractAllToAsync(destination, false, (error) => {
+            const files = walk(destination);
+            expect(files.sort()).to.deep.equal(
+                [
+                    pth.normalize("./test/xxx/attributes_test/asd/New Text Document.txt"),
+                    pth.normalize("./test/xxx/attributes_test/blank file.txt"),
+                    pth.normalize("./test/xxx/attributes_test/New folder/hidden.txt"),
+                    pth.normalize("./test/xxx/attributes_test/New folder/hidden_readonly.txt"),
+                    pth.normalize("./test/xxx/attributes_test/New folder/readonly.txt"),
+                    pth.normalize("./test/xxx/utes_test/New folder/somefile.txt")
+                ].sort()
+            );
+            done();
+        });
     });
 
     it("zip pathTraversal", () => {

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -28,7 +28,7 @@ describe("adm-zip", () => {
         );
     });
 
-    it("zip.extractAllToAsync()", (done) => {
+    it("zip.extractAllToAsync(destination, false, false, callback)", (done) => {
         const zip = new Zip("./test/assets/ultra.zip");
         zip.extractAllToAsync(destination, false, false, (error) => {
             const files = walk(destination);
@@ -44,6 +44,10 @@ describe("adm-zip", () => {
             );
             done();
         });
+    });
+    
+    it("zip.extractAllToAsync(destination, false, callback)", (done) => {
+        const zip = new Zip("./test/assets/ultra.zip");
         zip.extractAllToAsync(destination, false, (error) => {
             const files = walk(destination);
             expect(files.sort()).to.deep.equal(


### PR DESCRIPTION
issue cthackers#389
Due to the wrong initialization order, an error will be caused when three parameters are given and the last parameter is a callback function.