### PR TITLE
Fixed spelling

### DIFF
--- a/headers/mainHeader.js
+++ b/headers/mainHeader.js
@@ -76,7 +76,7 @@ module.exports = function () {
                 // total number of entries
                 _totalEntries = Utils.readBigUInt64LE(data, Constants.ZIP64TOT);
                 // central directory size in bytes
-                _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZ);
+                _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZE);
                 // offset of first CEN header
                 _offset = Utils.readBigUInt64LE(data, Constants.ZIP64OFF);
 
@@ -127,3 +127,4 @@ module.exports = function () {
         }
     };
 };
+ // Misspelled 


### PR DESCRIPTION
I noticed a reference to a constant that doesn't exist.
I looked through the rest of the constants and didn't see any others that were spelled wrong.

Hopefully this fixes some hidden bug!