### PR TITLE
fix the issue: addLocalFolderAsync causes stack overflow when a lot of files are filtered

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -375,7 +375,9 @@ module.exports = function (/**String*/ input, /** object */ options) {
                                     }
                                 });
                             } else {
-                                next();
+                                process.nextTick(() => {
+                                    next();
+                                });
                             }
                         } else {
                             callback(true, undefined);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adm-zip",
-  "version": "0.5.6",
+  "version": "0.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adm-zip",
-      "version": "0.5.6",
+      "version": "0.5.9",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.3.4",


### PR DESCRIPTION
the 'next' function is recursive, when a lot of files be filtered, too many tasks are pushed into stack, and the error below throws:
UnhandledException: [RangeError] Maximum call stack size exceeded

the pull request make the 'next' function to be called in next tick, to avoid the problem