### PR TITLE
fix: throw empty error in extractAllToAsync on operation done

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -710,9 +710,9 @@ module.exports = function (/**String*/ input, /** object */ options) {
                                     callback(getError("Unable to set times", filePath));
                                     return;
                                 }
-                                fileEntries.delete(entry);
                                 // call the callback if it was last entry
                                 done();
+                                fileEntries.delete(entry);
                             });
                         });
                     }


### PR DESCRIPTION
When extraction for each fileEntry is done, on should callback first before deleting the entry since the implementation of done function will always check and throw if current fileEntries is empty.