### PR TITLE
fix extra data lost when write zip

### DIFF
--- a/zipFile.js
+++ b/zipFile.js
@@ -259,7 +259,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                 // 1.2. postheader - data after data header
                 const postHeader = Buffer.alloc(entryNameLen + entry.extra.length);
                 entry.rawEntryName.copy(postHeader, 0);
-                postHeader.copy(entry.extra, entryNameLen);
+                entry.extra.copy(postHeader, entryNameLen);
 
                 // 2. offsets
                 const dataLength = dataHeader.length + postHeader.length + compressedData.length;


### PR DESCRIPTION
It will damage certain files (such as cannot be extracted in certain software, and the modification date is lost).
The additional unit test has been included in the next PR.