### PR TITLE
Extraction of password protected zip entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ var AdmZip = require("adm-zip");
 
 // reading archives
 var zip = new AdmZip("./my_file.zip");
-var zipEntries = zip.getEntries(); // an array of ZipEntry records
+var password = "1234567890";
+var zipEntries = zip.getEntries(); // an array of ZipEntry records - add password parameter if entries are password protected
 
 zipEntries.forEach(function (zipEntry) {
     console.log(zipEntry.toString()); // outputs zip entries information

--- a/adm-zip.js
+++ b/adm-zip.js
@@ -471,7 +471,8 @@ module.exports = function (/**String*/ input, /** object */ options) {
          *
          * @return Array
          */
-        getEntries: function () {
+        getEntries: function (/**String*/ password) {
+            _zip.password=password;
             return _zip ? _zip.entries : [];
         },
 
@@ -548,7 +549,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
                 return true;
             }
 
-            var content = item.getData();
+            var content = item.getData(_zip.password);
             if (!content) throw new Error(Utils.Errors.CANT_EXTRACT_FILE);
 
             if (filetools.fs.existsSync(target) && !overwrite) {

--- a/zipFile.js
+++ b/zipFile.js
@@ -8,6 +8,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
         _comment = Buffer.alloc(0),
         mainHeader = new Headers.MainHeader(),
         loadedEntries = false;
+    var password = null;
 
     // assign options
     const opts = Object.assign(Object.create(null), options);


### PR DESCRIPTION
Addes small changes to extract entries prottected by password. If entrie is not password prottected, it's extracted even password is provided.

```javascript
var AdmZip = require("adm-zip");

// reading archives
var zip = new AdmZip("./my_file.zip");
var password = "1234567890";
var zipEntries = zip.getEntries(password ); // an array of ZipEntry records - add password parameter if entries are password protected

zipEntries.forEach(function (zipEntry) {
    console.log(zipEntry.toString()); // outputs zip entries information
    if (zipEntry.entryName == "my_file.txt") {
        console.log(zipEntry.getData().toString("utf8"));
    }
});
```
