### PR TITLE
fix: typo encrypted

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -161,7 +161,7 @@ module.exports = function () {
             _offset = Math.max(0, val) >>> 0;
         },
 
-        get encripted() {
+        get encrypted() {
             return (_flags & 1) === 1;
         },
 

--- a/zipEntry.js
+++ b/zipEntry.js
@@ -53,7 +53,7 @@ module.exports = function (/*Buffer*/ input) {
             return compressedData;
         }
 
-        if (_entryHeader.encripted) {
+        if (_entryHeader.encrypted) {
             if ("string" !== typeof pass && !Buffer.isBuffer(pass)) {
                 throw new Error("ADM-ZIP: Incompatible password parameter");
             }


### PR DESCRIPTION
`encryited -> encrypted`