### PR TITLE
Header updates

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -25,7 +25,7 @@ module.exports = function () {
     // Without it file names may be corrupted for other apps when file names use unicode chars
     _flags |= Constants.FLG_EFS;
 
-    var _dataHeader = {};
+    var _localHeader = {};
 
     function setTime(val) {
         val = new Date(val);
@@ -170,20 +170,20 @@ module.exports = function () {
         },
 
         get realDataOffset() {
-            return _offset + Constants.LOCHDR + _dataHeader.fnameLen + _dataHeader.extraLen;
+            return _offset + Constants.LOCHDR + _localHeader.fnameLen + _localHeader.extraLen;
         },
 
-        get dataHeader() {
-            return _dataHeader;
+        get localHeader() {
+            return _localHeader;
         },
 
-        loadDataHeaderFromBinary: function (/*Buffer*/ input) {
+        loadLocalHeaderFromBinary: function (/*Buffer*/ input) {
             var data = input.slice(_offset, _offset + Constants.LOCHDR);
             // 30 bytes and should start with "PK\003\004"
             if (data.readUInt32LE(0) !== Constants.LOCSIG) {
                 throw new Error(Utils.Errors.INVALID_LOC);
             }
-            _dataHeader = {
+            _localHeader = {
                 // version needed to extract
                 version: data.readUInt16LE(Constants.LOCVER),
                 // general purpose bit flag
@@ -242,7 +242,7 @@ module.exports = function () {
             _offset = data.readUInt32LE(Constants.CENOFF);
         },
 
-        dataHeaderToBinary: function () {
+        localHeaderToBinary: function () {
             // LOC header size (30 bytes)
             var data = Buffer.alloc(Constants.LOCHDR);
             // "PK\003\004"

--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -165,7 +165,7 @@ module.exports = function () {
             return (_flags & 1) === 1;
         },
 
-        get entryHeaderSize() {
+        get centralHeaderSize() {
             return Constants.CENHDR + _fnameLen + _extraLen + _comLen;
         },
 
@@ -268,7 +268,7 @@ module.exports = function () {
             return data;
         },
 
-        entryHeaderToBinary: function () {
+        centralHeaderToBinary: function () {
             // CEN header size (46 bytes)
             var data = Buffer.alloc(Constants.CENHDR + _fnameLen + _extraLen + _comLen);
             // "PK\001\002"
@@ -329,7 +329,7 @@ module.exports = function () {
                 inAttr: _inattr,
                 attr: _attr,
                 offset: _offset,
-                entryHeaderSize: bytes(Constants.CENHDR + _fnameLen + _extraLen + _comLen)
+                centralHeaderSize: bytes(Constants.CENHDR + _fnameLen + _extraLen + _comLen)
             };
         },
 

--- a/test/header.js
+++ b/test/header.js
@@ -81,7 +81,7 @@ describe("headers", () => {
     });
 
     describe("entry-header", () => {
-        const entryHeader = require("../headers/entryHeader");
+        const centralHeader = require("../headers/entryHeader");
         const datestamp = [1981, 3, 1, 12, 10, 10];
         const readBuf = Buffer.from("504b0102140014000008080045618102efbeadde0001000000020000000000000000000000000000000000000000", "hex");
 
@@ -106,7 +106,7 @@ describe("headers", () => {
         };
 
         it("compare binary header values with some predetermined values", () => {
-            const head = new entryHeader();
+            const head = new centralHeader();
             head.loadFromBinary(readBuf);
 
             for (const name in readBufValues) {
@@ -114,7 +114,7 @@ describe("headers", () => {
                 head[name] = readBufValues[name];
             }
 
-            expect(head.entryHeaderSize).to.equal(46);
+            expect(head.centralHeaderSize).to.equal(46);
 
             // split into individual values by local time or timezone messes up our results
             expect([head.time.getFullYear(), head.time.getMonth(), head.time.getDate(), head.time.getHours(), head.time.getMinutes(), head.time.getSeconds()]).to.eql(datestamp);
@@ -135,7 +135,7 @@ describe("headers", () => {
                 inAttr: 0,
                 attr: 0,
                 offset: 0,
-                entryHeaderSize: "46 bytes"
+                centralHeaderSize: "46 bytes"
             };
 
             headerdata.time = head.time;
@@ -143,16 +143,16 @@ describe("headers", () => {
         });
 
         it("read binary and create new binary from it, they have to be equal", () => {
-            const head = new entryHeader();
+            const head = new centralHeader();
             head.loadFromBinary(readBuf);
-            const buf = head.entryHeaderToBinary();
+            const buf = head.centralHeaderToBinary();
 
             expect(buf.length).to.equal(readBuf.length);
             expect(buf).to.eql(readBuf);
         });
 
         it("construct header with values and compare, binaries have to be equal", () => {
-            const head = new entryHeader();
+            const head = new centralHeader();
 
             // Set Values
             for (const name in readBufValues) {
@@ -164,20 +164,20 @@ describe("headers", () => {
             // if time is constructed by new Date() it is also in local zone and so it cancels possible timezone difference
             head.time = new Date(...datestamp);
 
-            const buf = head.entryHeaderToBinary();
+            const buf = head.centralHeaderToBinary();
 
             expect(buf.length).to.equal(readBuf.length);
             expect(buf).to.eql(readBuf);
         });
 
-        it("entryHeaderSize results if postdata is specified", () => {
-            const head = new entryHeader();
+        it("centralHeaderSize results if postdata is specified", () => {
+            const head = new centralHeader();
 
             head.fileNameLength = 100;
             head.commentLength = 200;
             head.extraLength = 100;
 
-            expect(head.entryHeaderSize).to.equal(446);
+            expect(head.centralHeaderSize).to.equal(446);
         });
 
         describe("local-header", () => {
@@ -195,7 +195,7 @@ describe("headers", () => {
             };
 
             it("compare binary header values with predetermined values", () => {
-                const head = new entryHeader();
+                const head = new centralHeader();
                 head.loadFromBinary(readBuf);
                 head.loadLocalHeaderFromBinary(localHeader);
 
@@ -205,7 +205,7 @@ describe("headers", () => {
             });
 
             it("read binary and create new binary from it, they have to be equal", () => {
-                const head = new entryHeader();
+                const head = new centralHeader();
                 head.loadFromBinary(readBuf);
                 head.loadLocalHeaderFromBinary(localHeader);
 
@@ -216,7 +216,7 @@ describe("headers", () => {
             });
 
             it("construct header by values and compare binaries have to be equal", () => {
-                const head = new entryHeader();
+                const head = new centralHeader();
                 head.loadFromBinary(readBuf);
 
                 // Set Values

--- a/test/header.js
+++ b/test/header.js
@@ -180,10 +180,10 @@ describe("headers", () => {
             expect(head.entryHeaderSize).to.equal(446);
         });
 
-        describe("data-header", () => {
-            const dataheader = Buffer.from("504b030414000008080045618102efbeadde000100000002000000000000", "hex");
+        describe("local-header", () => {
+            const localHeader = Buffer.from("504b030414000008080045618102efbeadde000100000002000000000000", "hex");
 
-            const dataHeaderValues = {
+            const localHeaderValues = {
                 compressedSize: 0x100,
                 crc: 0xdeadbeef,
                 extraLen: 0,
@@ -197,22 +197,22 @@ describe("headers", () => {
             it("compare binary header values with predetermined values", () => {
                 const head = new entryHeader();
                 head.loadFromBinary(readBuf);
-                head.loadDataHeaderFromBinary(dataheader);
+                head.loadLocalHeaderFromBinary(localHeader);
 
-                for (const name in dataHeaderValues) {
-                    expect(head.dataHeader[name]).to.equal(dataHeaderValues[name]);
+                for (const name in localHeaderValues) {
+                    expect(head.localHeader[name]).to.equal(localHeaderValues[name]);
                 }
             });
 
             it("read binary and create new binary from it, they have to be equal", () => {
                 const head = new entryHeader();
                 head.loadFromBinary(readBuf);
-                head.loadDataHeaderFromBinary(dataheader);
+                head.loadLocalHeaderFromBinary(localHeader);
 
-                const buf = head.dataHeaderToBinary();
+                const buf = head.localHeaderToBinary();
 
-                expect(buf.length).to.equal(dataheader.length);
-                expect(buf).to.eql(dataheader);
+                expect(buf.length).to.equal(localHeader.length);
+                expect(buf).to.eql(localHeader);
             });
 
             it("construct header by values and compare binaries have to be equal", () => {
@@ -229,10 +229,10 @@ describe("headers", () => {
                 // if time is constructed by new Date() it is also in local zone and so it cancels possible timezone difference
                 head.time = new Date(...datestamp);
 
-                const buf = head.dataHeaderToBinary();
+                const buf = head.localHeaderToBinary();
 
-                expect(buf.length).to.equal(dataheader.length);
-                expect(buf).to.eql(dataheader);
+                expect(buf.length).to.equal(localHeader.length);
+                expect(buf).to.eql(localHeader);
             });
         });
     });

--- a/zipFile.js
+++ b/zipFile.js
@@ -34,7 +34,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             entry.header = inBuffer.slice(tmp, (tmp += Utils.Constants.CENHDR));
             entry.entryName = inBuffer.slice(tmp, (tmp += entry.header.fileNameLength));
 
-            index += entry.header.entryHeaderSize;
+            index += entry.header.centralHeaderSize;
 
             callback(entry);
         }
@@ -58,7 +58,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
 
             if (entry.header.commentLength) entry.comment = inBuffer.slice(tmp, tmp + entry.header.commentLength);
 
-            index += entry.header.entryHeaderSize;
+            index += entry.header.centralHeaderSize;
 
             entryList[i] = entry;
             entryTable[entry.entryName] = entry;

--- a/zipFile.js
+++ b/zipFile.js
@@ -243,7 +243,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             sortEntries();
 
             const dataBlock = [];
-            const entryHeaders = [];
+            const headerBlocks = [];
             let totalSize = 0;
             let dindex = 0;
 
@@ -253,30 +253,25 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             for (const entry of entryList) {
                 // compress data and set local and entry header accordingly. Reason why is called first
                 const compressedData = entry.getCompressedData();
-                // 1. construct data header
                 entry.header.offset = dindex;
-                const dataHeader = entry.header.dataHeaderToBinary();
-                const entryNameLen = entry.rawEntryName.length;
-                // 1.2. postheader - data after data header
-                const postHeader = Buffer.alloc(entryNameLen + entry.extra.length);
-                entry.rawEntryName.copy(postHeader, 0);
-                entry.extra.copy(postHeader, entryNameLen);
+
+                // 1. construct local header
+                const localHeader = entry.packLocalHeader();
 
                 // 2. offsets
-                const dataLength = dataHeader.length + postHeader.length + compressedData.length;
+                const dataLength = localHeader.length + compressedData.length;
                 dindex += dataLength;
 
                 // 3. store values in sequence
-                dataBlock.push(dataHeader);
-                dataBlock.push(postHeader);
+                dataBlock.push(localHeader);
                 dataBlock.push(compressedData);
 
-                // 4. construct entry header
-                const entryHeader = entry.packHeader();
-                entryHeaders.push(entryHeader);
+                // 4. construct central header
+                const centralHeader = entry.packCentralHeader();
+                headerBlocks.push(centralHeader);
                 // 5. update main header
-                mainHeader.size += entryHeader.length;
-                totalSize += dataLength + entryHeader.length;
+                mainHeader.size += centralHeader.length;
+                totalSize += dataLength + centralHeader.length;
             }
 
             totalSize += mainHeader.mainHeaderSize; // also includes zip file comment length
@@ -292,7 +287,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             }
 
             // write central directory entries
-            for (const content of entryHeaders) {
+            for (const content of headerBlocks) {
                 content.copy(outBuffer, dindex);
                 dindex += content.length;
             }
@@ -315,7 +310,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                 sortEntries();
 
                 const dataBlock = [];
-                const entryHeaders = [];
+                const centralHeaders = [];
                 let totalSize = 0;
                 let dindex = 0;
 
@@ -323,29 +318,30 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                 mainHeader.offset = 0;
 
                 const compress2Buffer = function (entryLists) {
-                    if (entryLists.length) {
-                        const entry = entryLists.pop();
+                    if (entryLists.length > 0) {
+                        const entry = entryLists.shift();
                         const name = entry.entryName + entry.extra.toString();
                         if (onItemStart) onItemStart(name);
                         entry.getCompressedDataAsync(function (compressedData) {
                             if (onItemEnd) onItemEnd(name);
-
                             entry.header.offset = dindex;
-                            // data header
-                            const dataHeader = entry.header.dataHeaderToBinary();
-                            const postHeader = Buffer.alloc(name.length, name);
-                            const dataLength = dataHeader.length + postHeader.length + compressedData.length;
 
+                            // 1. construct local header
+                            const localHeader = entry.packLocalHeader();
+
+                            // 2. offsets
+                            const dataLength = localHeader.length + compressedData.length;
                             dindex += dataLength;
 
-                            dataBlock.push(dataHeader);
-                            dataBlock.push(postHeader);
+                            // 3. store values in sequence
+                            dataBlock.push(localHeader);
                             dataBlock.push(compressedData);
 
-                            const entryHeader = entry.packHeader();
-                            entryHeaders.push(entryHeader);
-                            mainHeader.size += entryHeader.length;
-                            totalSize += dataLength + entryHeader.length;
+                            // central header
+                            const centalHeader = entry.packCentralHeader();
+                            centralHeaders.push(centalHeader);
+                            mainHeader.size += centalHeader.length;
+                            totalSize += dataLength + centalHeader.length;
 
                             compress2Buffer(entryLists);
                         });
@@ -360,7 +356,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                             content.copy(outBuffer, dindex); // write data blocks
                             dindex += content.length;
                         });
-                        entryHeaders.forEach(function (content) {
+                        centralHeaders.forEach(function (content) {
                             content.copy(outBuffer, dindex); // write central directory entries
                             dindex += content.length;
                         });
@@ -376,7 +372,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                     }
                 };
 
-                compress2Buffer(entryList);
+                compress2Buffer(Array.from(entryList));
             } catch (e) {
                 onFail(e);
             }


### PR DESCRIPTION
- Moved `localheader` creation into one place `packLocalHeader` in `zipEntry`
- renamed `dataheader` to `local header` (like it is called in ZIP spec)
- renamed `entryheader` to `central header` (~)
- kept `entryheader` as overall name for `central header` and `local header`
- fixed issue with `"toAsyncBuffer"` where after that command all entries are gone