### PR TITLE
inital "decoder" functionality

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -46,6 +46,11 @@ module.exports = function (/**String*/ input, /** object */ options) {
     // instanciate utils filesystem
     const filetools = new Utils(opts);
 
+    opts.decoder = Utils.decoder;
+    if (typeof opts.decoder !== "object" || typeof opts.decoder.encode !== "function" || typeof opts.decoder.decode !== "function") {
+        opts.decoder = Utils.decoder;
+    }
+
     // if input is file name we retrieve its content
     if (input && "string" === typeof input) {
         // load zip file
@@ -553,7 +558,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
 
             // prepare new entry
             if (!update) {
-                entry = new ZipEntry();
+                entry = new ZipEntry(opts);
                 entry.entryName = entryName;
             }
             entry.comment = comment || "";
@@ -731,7 +736,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
                 throw new Error(Utils.Errors.NO_ZIP);
             }
             _zip.entries.forEach(function (entry) {
-                var entryName = sanitize(targetPath, canonical(entry.entryName.toString()));
+                var entryName = sanitize(targetPath, canonical(entry.entryName));
                 if (entry.isDirectory) {
                     filetools.makeDir(entryName);
                     return;
@@ -784,7 +789,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
 
             targetPath = pth.resolve(targetPath);
             // convert entryName to
-            const getPath = (entry) => sanitize(targetPath, pth.normalize(canonical(entry.entryName.toString())));
+            const getPath = (entry) => sanitize(targetPath, pth.normalize(canonical(entry.entryName)));
             const getError = (msg, file) => new Error(msg + ': "' + file + '"');
 
             // separate directories from files
@@ -819,7 +824,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
                     if (err) {
                         next(err);
                     } else {
-                        const entryName = pth.normalize(canonical(entry.entryName.toString()));
+                        const entryName = pth.normalize(canonical(entry.entryName));
                         const filePath = sanitize(targetPath, entryName);
                         entry.getDataAsync(function (content, err_1) {
                             if (err_1) {

--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -63,6 +63,17 @@ module.exports = function () {
             _flags = val;
         },
 
+        get flags_efs() {
+            return (_flags & Constants.FLG_EFS) > 0;
+        },
+        set flags_efs(val) {
+            if (val) {
+                _flags |= Constants.FLG_EFS;
+            } else {
+                _flags &= ~Constants.FLG_EFS;
+            }
+        },
+
         get method() {
             return _method;
         },

--- a/util/decoder.js
+++ b/util/decoder.js
@@ -1,0 +1,5 @@
+module.exports = {
+    efs: true,
+    encode: (data) => Buffer.from(data, "utf8"),
+    decode: (data) => data.toString("utf8")
+};

--- a/util/index.js
+++ b/util/index.js
@@ -2,3 +2,4 @@ module.exports = require("./utils");
 module.exports.Constants = require("./constants");
 module.exports.Errors = require("./errors");
 module.exports.FileAttr = require("./fattr");
+module.exports.decoder = require("./decoder");

--- a/util/utils.js
+++ b/util/utils.js
@@ -267,14 +267,14 @@ Utils.sanitize = function (/*string*/ prefix, /*string*/ name) {
 };
 
 // converts buffer, Uint8Array, string types to buffer
-Utils.toBuffer = function toBuffer(/*buffer, Uint8Array, string*/ input) {
+Utils.toBuffer = function toBuffer(/*buffer, Uint8Array, string*/ input, /* function */ encoder) {
     if (Buffer.isBuffer(input)) {
         return input;
     } else if (input instanceof Uint8Array) {
         return Buffer.from(input);
     } else {
         // expect string all other values are invalid and return empty buffer
-        return typeof input === "string" ? Buffer.from(input, "utf8") : Buffer.alloc(0);
+        return typeof input === "string" ? encoder(input) : Buffer.alloc(0);
     }
 };
 

--- a/zipFile.js
+++ b/zipFile.js
@@ -11,9 +11,9 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
     var password = null;
 
     // assign options
-    const opts = Object.assign(Object.create(null), options);
+    const opts = options;
 
-    const { noSort } = opts;
+    const { noSort, decoder } = opts;
 
     if (inBuffer) {
         // is a memory buffer
@@ -29,7 +29,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
 
         for (let i = 0; i < totalEntries; i++) {
             let tmp = index;
-            const entry = new ZipEntry(inBuffer);
+            const entry = new ZipEntry(opts, inBuffer);
 
             entry.header = inBuffer.slice(tmp, (tmp += Utils.Constants.CENHDR));
             entry.entryName = inBuffer.slice(tmp, (tmp += entry.header.fileNameLength));
@@ -50,7 +50,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
         var index = mainHeader.offset; // offset of first CEN header
         for (var i = 0; i < entryList.length; i++) {
             var tmp = index,
-                entry = new ZipEntry(inBuffer);
+                entry = new ZipEntry(opts, inBuffer);
             entry.header = inBuffer.slice(tmp, (tmp += Utils.Constants.CENHDR));
 
             entry.entryName = inBuffer.slice(tmp, (tmp += entry.header.fileNameLength));
@@ -134,10 +134,10 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
          * @return {String}
          */
         get comment() {
-            return _comment.toString();
+            return decoder.decode(_comment);
         },
         set comment(val) {
-            _comment = Utils.toBuffer(val);
+            _comment = Utils.toBuffer(val, decoder.encode);
             mainHeader.commentLength = _comment.length;
         },
 


### PR DESCRIPTION
- "decoder" lets user override name and commend buffer handling
- "efs" flag would be activated by default
- "efs" flag can be overwritten by creating custom decoder object

there is still some work to do:
 _some cases header & entry become uncoupled. It shouldn't happen if use entry getters & setters. maybe move entryName &
 comment to header._