### PR TITLE
using writeZip() twice throws "Invalid LOC header (bad signature)" error

### DIFF
--- a/test/mocha.js
+++ b/test/mocha.js
@@ -114,6 +114,21 @@ describe("adm-zip", () => {
         expect(zip1Entries).to.deep.equal(["windows/system32/drivers/etc/hosts.txt", "system32/drivers/etc/hosts.txt", "drivers/etc/hosts.txt", "hosts.txt"]);
     });
 
+    // Issue 64
+    it("zip.writeZip - multiple times", () => {
+        const zip = new Zip("./test/assets/ultra.zip");
+        const fileName = pth.resolve(destination, "writezip");
+
+        for (let i = 0; i < 5; i++) zip.writeZip(`${fileName}.${i}.zip`);
+
+        const expected_list = ["./test/xxx/writezip.0.zip", "./test/xxx/writezip.1.zip", "./test/xxx/writezip.2.zip", "./test/xxx/writezip.3.zip", "./test/xxx/writezip.4.zip"].map(
+            pth.normalize
+        );
+
+        const files = walk(destination);
+        expect(files.sort()).to.deep.equal(expected_list);
+    });
+
     /*
     it("repro: symlink", () => {
         const zip = new Zip("./test/assets/symlink.zip");

--- a/zipFile.js
+++ b/zipFile.js
@@ -302,6 +302,13 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             }
             mh.copy(outBuffer, dindex);
 
+            // Since we update entry and main header offsets,
+            // they are no longer valid and we have to reset content
+            // (Issue 64)
+
+            inBuffer = outBuffer;
+            loadedEntries = false;
+
             return outBuffer;
         },
 
@@ -370,6 +377,13 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
                         }
 
                         mh.copy(outBuffer, dindex); // write main header
+
+                        // Since we update entry and main header offsets, they are no
+                        // longer valid and we have to reset content using our new buffer
+                        // (Issue 64)
+
+                        inBuffer = outBuffer;
+                        loadedEntries = false;
 
                         onSuccess(outBuffer);
                     }


### PR DESCRIPTION
Issue 64 description says `writeZip() throws "Invalid LOC header (bad signature)" error`.

I was not able replicate it with first call, but calling it twice generated it like 80 %.