### PR TITLE
Fixing preserving linux file permissions

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -183,7 +183,7 @@ module.exports = function () {
 
         // get Unix file permissions
         get fileAttr() {
-            return uint16(_attr >> 16) & 0xfff;
+            return (_attr || 0) >> 16 & 0xfff;
         },
 
         get offset() {

--- a/test/header.js
+++ b/test/header.js
@@ -142,6 +142,16 @@ describe("headers", () => {
             expect(head.toJSON()).to.eql(headerdata);
         });
 
+        it("handles fileAttr when attr above 0x80000000", () => {
+            const attr = 0x81E80000;
+
+            const head = new centralHeader();
+            head.loadFromBinary(readBuf);
+            head.attr = attr;
+
+            expect(head.fileAttr).to.equal(0x01E8);
+        });
+
         it("read binary and create new binary from it, they have to be equal", () => {
             const head = new centralHeader();
             head.loadFromBinary(readBuf);


### PR DESCRIPTION
Resolving the issue where fileAttr incorrectly parses as 0 when it should be a value for certain values of attr. This should resolve the issue with preserving file permissions in 0.5.15 (#530)