### PR TITLE
entryHeader time setter more tolerant

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -98,6 +98,7 @@ module.exports = function () {
             return Utils.fromDOS2Date(this.timeval);
         },
         set time(val) {
+            val = new Date(val);
             this.timeval = Utils.fromDate2DOS(val);
         },
 


### PR DESCRIPTION
Suggested fix for #539 to ensure that existing code is not broken.

* Allows parameter to the `time` setter to be any parameter accepted by the `Date` constructor
* Re-instates the functionality removed at: https://github.com/cthackers/adm-zip/pull/518/commits/6e717adfd9f7ae3ed5b9fd0d6861d851b592eda1#diff-6af03ff88c79ec964bc6482f32561df5347e564bd58f5aa1e1801682d4c49842L33
* Closes #539