### PR TITLE
prevent crashes when process.versions is an empty object

### DIFF
--- a/methods/inflater.js
+++ b/methods/inflater.js
@@ -1,4 +1,4 @@
-const version = +(process.versions ? process.versions.node : "").split(".")[0] || 0;
+const version = +(process?.versions?.node ?? "").split(".")[0] || 0;
 
 module.exports = function (/*Buffer*/ inbuf, /*number*/ expectedLength) {
     var zlib = require("zlib");


### PR DESCRIPTION
I'm getting crashes if process.versions is set to `{}` as it accesses `.node` with no further checks, and calls `.split()` on `undefined`. Looks like the original logic assumed that if `process.versions` was set, then `.node` would be too.

@5saviahv sorry for the tag, just wanted to make sure you'd see this as the last commit was a little while ago 🙂