### PR TITLE
created only if the directory does not exist

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -49,7 +49,11 @@ Utils.prototype.makeDir = function (/*String*/ folder) {
             try {
                 stat = self.fs.statSync(resolvedPath);
             } catch (e) {
-                self.fs.mkdirSync(resolvedPath);
+                if (e.message.startWith('ENOENT')) {
+                    self.fs.mkdirSync(resolvedPath);
+                } else {
+                    throw e;
+                }
             }
             if (stat && stat.isFile()) throw Errors.FILE_IN_THE_WAY(`"${resolvedPath}"`);
         });


### PR DESCRIPTION
`statSync` 只有遇到目录不存在的情况时，才执行创建目录的操作。

当遇到其他错误，比如权限问题，此时，不应该执行创建目录的操作，而是把错误抛出去，便于发现真正的问题。
