### PR TITLE
Create only if the directory does not exist

### DIFF
--- a/util/utils.js
+++ b/util/utils.js
@@ -49,7 +49,11 @@ Utils.prototype.makeDir = function (/*String*/ folder) {
             try {
                 stat = self.fs.statSync(resolvedPath);
             } catch (e) {
-                self.fs.mkdirSync(resolvedPath);
+                if (e.message && e.message.startsWith('ENOENT')) {
+                    self.fs.mkdirSync(resolvedPath);
+                } else {
+                    throw e;
+                }
             }
             if (stat && stat.isFile()) throw Errors.FILE_IN_THE_WAY(`"${resolvedPath}"`);
         });


### PR DESCRIPTION
`statSync` only performs a catalogue creation operation if it encounters a situation where the catalogue does not exist.

When other errors are encountered, such as permissions problems, the create directory operation should not be performed, but rather the error should be thrown out to make it easier to find the real problem.