### PR TITLE
support for writing zip64

### DIFF
--- a/headers/mainHeader.js
+++ b/headers/mainHeader.js
@@ -9,6 +9,8 @@ module.exports = function () {
         _offset = 0,
         _commentLength = 0;
 
+    const needsZip64 = () => _volumeEntries > Constants.EF_ZIP64_OR_16 || _totalEntries > Constants.EF_ZIP64_OR_16 || _size > Constants.EF_ZIP64_OR_32 || _offset > Constants.EF_ZIP64_OR_32;
+
     return {
         get diskEntries() {
             return _volumeEntries;
@@ -46,7 +48,7 @@ module.exports = function () {
         },
 
         get mainHeaderSize() {
-            return Constants.ENDHDR + _commentLength;
+            return (needsZip64() ? Constants.ZIP64HDR + Constants.END64HDR : 0) + Constants.ENDHDR + _commentLength;
         },
 
         loadFromBinary: function (/*Buffer*/ data) {
@@ -76,7 +78,7 @@ module.exports = function () {
                 // total number of entries
                 _totalEntries = Utils.readBigUInt64LE(data, Constants.ZIP64TOT);
                 // central directory size in bytes
-                _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZE);
+                _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZB);
                 // offset of first CEN header
                 _offset = Utils.readBigUInt64LE(data, Constants.ZIP64OFF);
 
@@ -85,22 +87,67 @@ module.exports = function () {
         },
 
         toBinary: function () {
-            var b = Buffer.alloc(Constants.ENDHDR + _commentLength);
+            if (!needsZip64()) {
+                var b = Buffer.alloc(Constants.ENDHDR + _commentLength);
+                // "PK 05 06" signature
+                b.writeUInt32LE(Constants.ENDSIG, 0);
+                b.writeUInt32LE(0, 4);
+                // number of entries on this volume
+                b.writeUInt16LE(_volumeEntries, Constants.ENDSUB);
+                // total number of entries
+                b.writeUInt16LE(_totalEntries, Constants.ENDTOT);
+                // central directory size in bytes
+                b.writeUInt32LE(_size, Constants.ENDSIZ);
+                // offset of first CEN header
+                b.writeUInt32LE(_offset, Constants.ENDOFF);
+                // zip file comment length
+                b.writeUInt16LE(_commentLength, Constants.ENDCOM);
+                // fill comment memory with spaces so no garbage is left there
+                b.fill(" ", Constants.ENDHDR);
+
+                return b;
+            }
+
+            var b = Buffer.alloc(this.mainHeaderSize);
+            let offset = 0;
+
+            // Zip64 end of central directory record.
+            b.writeUInt32LE(Constants.ZIP64SIG, offset);
+            Utils.writeBigUInt64LE(b, Constants.ZIP64HDR - Constants.ZIP64LEAD, offset + Constants.ZIP64SIZE);
+            b.writeUInt16LE(45, offset + Constants.ZIP64VEM);
+            b.writeUInt16LE(45, offset + Constants.ZIP64VER);
+            b.writeUInt32LE(0, offset + Constants.ZIP64DSK);
+            b.writeUInt32LE(0, offset + Constants.ZIP64DSKDIR);
+            Utils.writeBigUInt64LE(b, _volumeEntries, offset + Constants.ZIP64SUB);
+            Utils.writeBigUInt64LE(b, _totalEntries, offset + Constants.ZIP64TOT);
+            Utils.writeBigUInt64LE(b, _size, offset + Constants.ZIP64SIZB);
+            Utils.writeBigUInt64LE(b, _offset, offset + Constants.ZIP64OFF);
+
+            const zip64EndOffset = _offset + _size;
+            offset += Constants.ZIP64HDR;
+
+            // Zip64 end of central directory locator.
+            b.writeUInt32LE(Constants.END64SIG, offset);
+            b.writeUInt32LE(0, offset + Constants.END64START);
+            Utils.writeBigUInt64LE(b, zip64EndOffset, offset + Constants.END64OFF);
+            b.writeUInt32LE(1, offset + Constants.END64NUMDISKS);
+            offset += Constants.END64HDR;
+
             // "PK 05 06" signature
-            b.writeUInt32LE(Constants.ENDSIG, 0);
-            b.writeUInt32LE(0, 4);
+            b.writeUInt32LE(Constants.ENDSIG, offset);
+            b.writeUInt32LE(0, offset + 4);
             // number of entries on this volume
-            b.writeUInt16LE(_volumeEntries, Constants.ENDSUB);
+            b.writeUInt16LE(Math.min(_volumeEntries, Constants.EF_ZIP64_OR_16), offset + Constants.ENDSUB);
             // total number of entries
-            b.writeUInt16LE(_totalEntries, Constants.ENDTOT);
+            b.writeUInt16LE(Math.min(_totalEntries, Constants.EF_ZIP64_OR_16), offset + Constants.ENDTOT);
             // central directory size in bytes
-            b.writeUInt32LE(_size, Constants.ENDSIZ);
+            b.writeUInt32LE(Math.min(_size, Constants.EF_ZIP64_OR_32), offset + Constants.ENDSIZ);
             // offset of first CEN header
-            b.writeUInt32LE(_offset, Constants.ENDOFF);
+            b.writeUInt32LE(Math.min(_offset, Constants.EF_ZIP64_OR_32), offset + Constants.ENDOFF);
             // zip file comment length
-            b.writeUInt16LE(_commentLength, Constants.ENDCOM);
+            b.writeUInt16LE(_commentLength, offset + Constants.ENDCOM);
             // fill comment memory with spaces so no garbage is left there
-            b.fill(" ", Constants.ENDHDR);
+            b.fill(" ", offset + Constants.ENDHDR);
 
             return b;
         },

--- a/test/header.js
+++ b/test/header.js
@@ -4,6 +4,8 @@ const { expect } = require("chai");
 describe("headers", () => {
     describe("main-header", () => {
         const mainHeader = require("../headers/mainHeader");
+        const Constants = require("../util").Constants;
+        const Utils = require("../util");
         // empty zip file
         const empty = Buffer.from("504b0506000000000000000000000000000000000000", "hex");
         const readBuf = Buffer.from("504b050600000000cac0cefaed0b0000eeffc0000000", "hex");
@@ -57,6 +59,33 @@ describe("headers", () => {
 
             expect(mainh.commentLength).to.equal(5);
             expect(mainh.mainHeaderSize).to.equal(22 + 5);
+        });
+
+        it("writes zip64 end records when entry count exceeds classic zip limit", () => {
+            const mainh = new mainHeader();
+            mainh.totalEntries = 0x10000;
+            mainh.size = 123;
+            mainh.offset = 456;
+
+            const buf = mainh.toBinary();
+            const eocdOffset = Constants.ZIP64HDR + Constants.END64HDR;
+
+            expect(buf.length).to.equal(Constants.ZIP64HDR + Constants.END64HDR + Constants.ENDHDR);
+            expect(buf.readUInt32LE(0)).to.equal(Constants.ZIP64SIG);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64SIZE)).to.equal(Constants.ZIP64HDR - Constants.ZIP64LEAD);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64SUB)).to.equal(0x10000);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64TOT)).to.equal(0x10000);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64SIZB)).to.equal(123);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64OFF)).to.equal(456);
+
+            expect(buf.readUInt32LE(Constants.ZIP64HDR)).to.equal(Constants.END64SIG);
+            expect(Utils.readBigUInt64LE(buf, Constants.ZIP64HDR + Constants.END64OFF)).to.equal(579);
+
+            expect(buf.readUInt32LE(eocdOffset)).to.equal(Constants.ENDSIG);
+            expect(buf.readUInt16LE(eocdOffset + Constants.ENDSUB)).to.equal(Constants.EF_ZIP64_OR_16);
+            expect(buf.readUInt16LE(eocdOffset + Constants.ENDTOT)).to.equal(Constants.EF_ZIP64_OR_16);
+            expect(buf.readUInt32LE(eocdOffset + Constants.ENDSIZ)).to.equal(123);
+            expect(buf.readUInt32LE(eocdOffset + Constants.ENDOFF)).to.equal(456);
         });
 
         // try read empty file

--- a/test/zip64.test.js
+++ b/test/zip64.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { expect } = require("chai");
+const Zip = require("../adm-zip");
+
+describe("zip64", () => {
+    it("writes and reads archives with more than 65535 entries", function () {
+        this.timeout(10000);
+
+        const entryCount = 0x10000;
+        const zip = new Zip({ noSort: true });
+
+        for (let i = 0; i < entryCount; i++) {
+            zip.addFile(`file-${i}.txt`, "");
+        }
+
+        const buffer = zip.toBuffer();
+        const readZip = new Zip(buffer);
+
+        expect(readZip.getEntries()).to.have.lengthOf(entryCount);
+    });
+});

--- a/util/utils.js
+++ b/util/utils.js
@@ -321,6 +321,13 @@ Utils.readBigUInt64LE = function (/*Buffer*/ buffer, /*int*/ index) {
     return hi * 0x100000000 + lo;
 };
 
+Utils.writeBigUInt64LE = function (/*Buffer*/ buffer, /*Number*/ value, /*int*/ index) {
+    const lo = value >>> 0;
+    const hi = Math.floor(value / 0x100000000) >>> 0;
+    buffer.writeUInt32LE(lo, index);
+    buffer.writeUInt32LE(hi, index + 4);
+};
+
 Utils.fromDOS2Date = function (val) {
     return new Date(((val >> 25) & 0x7f) + 1980, Math.max(((val >> 21) & 0x0f) - 1, 0), Math.max((val >> 16) & 0x1f, 1), (val >> 11) & 0x1f, (val >> 5) & 0x3f, (val & 0x1f) << 1);
 };

--- a/zipFile.js
+++ b/zipFile.js
@@ -343,7 +343,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
             // write main header
             const mh = mainHeader.toBinary();
             if (_comment) {
-                _comment.copy(mh, Utils.Constants.ENDHDR); // add zip file comment
+                _comment.copy(mh, mh.length - _comment.length); // add zip file comment
             }
             mh.copy(outBuffer, dindex);
 
@@ -421,7 +421,7 @@ module.exports = function (/*Buffer|null*/ inBuffer, /** object */ options) {
 
                         const mh = mainHeader.toBinary();
                         if (_comment) {
-                            _comment.copy(mh, Utils.Constants.ENDHDR); // add zip file comment
+                            _comment.copy(mh, mh.length - _comment.length); // add zip file comment
                         }
 
                         mh.copy(outBuffer, dindex); // write main header


### PR DESCRIPTION
## Summary

Add ZIP64 footer writing support for archives that exceed classic ZIP end-of-central-directory limits.

Previously, creating an archive with more than 65,535 entries fails while writing the classic EOCD record because entry counts are stored as UInt16 values. This change writes ZIP64 end records when needed and keeps the classic EOCD compatibility record with saturated placeholder values.

## Changes

- Add a `writeBigUInt64LE` utility alongside the existing ZIP64 read helper.
- Emit ZIP64 end of central directory record and locator when entry count, central directory size, or central directory offset exceeds classic ZIP limits.
- Preserve the existing classic EOCD output path for small archives.
- Ensure ZIP comments are copied to the correct footer position when ZIP64 records are present.
- Add regression coverage for archives with more than 65,535 entries.

## Test Plan

- `npm test`

Result: `93 passing`