### PR TITLE
Fix Archive Utility failure on zips with empty directories (#558)

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -87,6 +87,7 @@ module.exports = function () {
             switch (val) {
                 case Constants.STORED:
                     this.version = 10;
+                    break;
                 case Constants.DEFLATED:
                 default:
                     this.version = 20;


### PR DESCRIPTION
Fix: add the missing `break` so STORED entries report v1.0 while DEFLATED entries keep v2.0, matching Info-ZIP. 

After the fix, archives with empty directories open correctly in Archive Utility, and the full test suite still passes.

fix <https://github.com/cthackers/adm-zip/issues/558>