### PR TITLE
Fix test() returning false for valid archives

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -727,7 +727,7 @@ module.exports = function (/**String*/ input, /** object */ options) {
                     if (entry.isDirectory) {
                         continue;
                     }
-                    var content = _zip.entries[entry].getData(pass);
+                    var content = entry.getData(pass);
                     if (!content) {
                         return false;
                     }

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -26,6 +26,15 @@ describe("adm-zip", () => {
         expect(files.sort()).to.deep.equal([pth.normalize("./test/xxx/test/test1.ext"), pth.normalize("./test/xxx/test/test2.ext"), pth.normalize("./test/xxx/test/test3.ext")]);
     });
 
+    it("test() returns true for a well-formed archive", () => {
+        const zip = new Zip();
+        zip.addFile("a.txt", Buffer.from("hello"));
+        zip.addFile("dir/b.txt", Buffer.from("world"));
+
+        const verify = new Zip(zip.toBuffer());
+        expect(verify.test()).to.equal(true);
+    });
+
     it("zip.addFile - add directory", () => {
         const zip1 = new Zip();
         zip1.addFile("dir11/", null);


### PR DESCRIPTION
Since 0.5.18, `test()` returns `false` for every valid archive.

The loop was switched to `for..of` (so `entry` is now the `ZipEntry` itself), but the body still did `_zip.entries[entry].getData(pass)` — indexing the entries array with an object yields `undefined`, so `.getData()` throws and the `catch` turns it into `return false`. Extraction is unaffected (it never calls `test()`), but any code using `test()` to validate an archive or verify a ZipCrypto password before extracting now rejects everything.

This reads `getData` off `entry` directly, matching what `for..of` yields. Added a test that builds a two-file archive and asserts `test()` is `true` — it fails on the current code and passes with this change.
